### PR TITLE
Add support for external Qhull and reentrant Qhull API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,11 +24,11 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${OUTPUT_LIBDIR})
 
 
 # Dynamic vs Static Linking
-option(DYNAMIC_SOLID "Set to ON to build SOLID for dynamic linking.  Use OFF for static." ON)
+option(BUILD_SHARED_LIBS "Set to ON to build SOLID for dynamic linking.  Use OFF for static." ON)
 
-if(NOT DYNAMIC_SOLID)
+if(NOT BUILD_SHARED_LIBS)
   add_definitions(-DSOLID_STATIC)
-endif(NOT DYNAMIC_SOLID)
+endif()
 
 option(USE_DOUBLES "Use double-precision floating-point numbers." OFF)
 
@@ -89,10 +89,10 @@ endif(MSVC)
 if(UNIX)
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -ffast-math -msse2 -mfpmath=sse")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti -Wall -ffast-math -msse2 -mfpmath=sse")
-  if (DYNAMIC_SOLID)
+  if (BUILD_SHARED_LIBS)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
-  endif(DYNAMIC_SOLID)
+  endif()
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -lrt")
 endif(UNIX)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,12 @@ if(NOT BUILD_SHARED_LIBS)
   add_definitions(-DSOLID_STATIC)
 endif()
 
+option(USE_EXTERNAL_QHULL "Use external Qhull library." OFF)
+
+if(USE_EXTERNAL_QHULL)
+  find_package(Qhull REQUIRED)
+endif()
+
 option(USE_DOUBLES "Use double-precision floating-point numbers." OFF)
 
 if(USE_DOUBLES)

--- a/CMakeModules/FindQhull.cmake
+++ b/CMakeModules/FindQhull.cmake
@@ -1,0 +1,46 @@
+include(FindPackageHandleStandardArgs)
+include(SelectLibraryConfigurations)
+
+find_path(Qhull_REENTRANT_INCLUDE_DIRS NAMES libqhull_r/qhull_ra.h qhull_r/qhull_ra.h)
+
+mark_as_advanced(Qhull_REENTRANT_INCLUDE_DIRS)
+
+if(BUILD_SHARED_LIBS)
+  find_library(Qhull_REENTRANT_LIBRARY_DEBUG NAMES qhull_rd)
+  find_library(Qhull_REENTRANT_LIBRARY_RELEASE NAMES qhull_r)
+else()
+  find_library(Qhull_REENTRANT_LIBRARY_DEBUG NAMES qhullstatic_rd)
+  find_library(Qhull_REENTRANT_LIBRARY_RELEASE NAMES qhullstatic_r)
+endif()
+
+select_library_configurations(Qhull_REENTRANT)
+
+find_path(Qhull_NON_REENTRANT_INCLUDE_DIRS NAMES libqhull/qhull_a.h qhull/qhull_a.h)
+
+mark_as_advanced(Qhull_NON_REENTRANT_INCLUDE_DIRS)
+
+if(BUILD_SHARED_LIBS)
+  find_library(Qhull_NON_REENTRANT_LIBRARY_DEBUG NAMES qhull_d)
+  find_library(Qhull_NON_REENTRANT_LIBRARY_RELEASE NAMES qhull)
+else()
+  find_library(Qhull_NON_REENTRANT_LIBRARY_DEBUG NAMES qhullstatic_d)
+  find_library(Qhull_NON_REENTRANT_LIBRARY_RELEASE NAMES qhullstatic)
+endif()
+
+select_library_configurations(Qhull_NON_REENTRANT)
+
+if(Qhull_REENTRANT_INCLUDE_DIRS AND Qhull_REENTRANT_LIBRARIES)
+  set(Qhull_INCLUDE_DIRS ${Qhull_REENTRANT_INCLUDE_DIRS})
+  set(Qhull_LIBRARIES ${Qhull_REENTRANT_LIBRARIES})
+  set(QHull_REENTRANT_FOUND TRUE)
+elseif(Qhull_NON_REENTRANT_INCLUDE_DIRS AND Qhull_NON_REENTRANT_LIBRARIES)
+  set(Qhull_INCLUDE_DIRS ${Qhull_NON_REENTRANT_INCLUDE_DIRS})
+  set(Qhull_LIBRARIES ${Qhull_NON_REENTRANT_LIBRARIES})
+  set(QHull_NON_REENTRANT_FOUND TRUE)
+endif()
+
+find_package_handle_standard_args(
+  Qhull
+  FOUND_VAR Qhull_FOUND
+  REQUIRED_VARS Qhull_INCLUDE_DIRS Qhull_LIBRARIES
+)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,10 @@
-add_subdirectory(qhull)
+include(CheckIncludeFile)
+include(CMakePushCheckState)
+
+if(NOT USE_EXTERNAL_QHULL)
+  add_subdirectory(qhull)
+  set(QHULL_TARGET_OBJECTS $<TARGET_OBJECTS:qhull>)
+endif()
 
 if(BUILD_SHARED_LIBS)
   add_definitions(-DSOLID_DLL_EXPORT)
@@ -78,11 +84,33 @@ add_library(solid3
   DT_RespTable.h
   DT_Scene.cpp
   DT_Scene.h
-  $<TARGET_OBJECTS:qhull>
+  ${QHULL_TARGET_OBJECTS}
 )
 
 target_include_directories(solid3 INTERFACE $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>)
 set_target_properties(solid3 PROPERTIES VERSION ${VERSION})
+
+if(USE_EXTERNAL_QHULL)
+  cmake_push_check_state(RESET)
+  set(CMAKE_REQUIRED_INCLUDES ${Qhull_INCLUDE_DIRS})
+  check_include_file(libqhull_r/qhull_ra.h HAVE_LIBQHULL_R_QHULL_RA_H)
+  if(HAVE_LIBQHULL_R_QHULL_RA_H)
+    add_definitions(-DHAVE_LIBQHULL_R_QHULL_RA_H)
+  else()
+    check_include_file(qhull_r/qhull_ra.h HAVE_QHULL_R_QHULL_RA_H)
+    if(HAVE_QHULL_R_QHULL_RA_H)
+      add_definitions(-DHAVE_QHULL_R_QHULL_RA_H)
+    else()
+      check_include_file(libqhull/qhull_a.h HAVE_LIBQHULL_QHULL_A_H)
+      if(HAVE_LIBQHULL_QHULL_A_H)
+        add_definitions(-DHAVE_LIBQHULL_QHULL_A_H)
+      endif()
+    endif()
+  endif()
+  cmake_pop_check_state()
+  target_include_directories(solid3 PRIVATE ${Qhull_INCLUDE_DIRS})
+  target_link_libraries(solid3 PRIVATE ${Qhull_LIBRARIES})
+endif()
 
 if(NOT CMAKE_VERSION VERSION_LESS 3.12)
     install(

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,12 +1,10 @@
 add_subdirectory(qhull)
 
-if(DYNAMIC_SOLID)
-  set(LIBRARY_TYPE "SHARED")
+if(BUILD_SHARED_LIBS)
   add_definitions(-DSOLID_DLL_EXPORT)
-else(DYNAMIC_SOLID)
-  set(LIBRARY_TYPE "STATIC")
+else()
   add_definitions(-DSOLID_STATIC)
-endif(DYNAMIC_SOLID)
+endif()
 
 include_directories(${PROJECT_SOURCE_DIR}/src)
 include_directories(${PROJECT_SOURCE_DIR}/src/broad)
@@ -19,7 +17,7 @@ set(SOLID_PUBLIC_HEADERS
   ${PROJECT_SOURCE_DIR}/include/SOLID_types.h
 )
 
-add_library(solid3 ${LIBRARY_TYPE}
+add_library(solid3
   ${SOLID_PUBLIC_HEADERS}
   broad/BP_C-api.cpp
   broad/BP_Endpoint.h
@@ -102,7 +100,7 @@ else()
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT runtime NAMELINK_SKIP
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT runtime
     )
-    if(DYNAMIC_SOLID)
+    if(BUILD_SHARED_LIBS)
         install(
             TARGETS solid3
             EXPORT solid3
@@ -116,6 +114,6 @@ install(
     COMPONENT development
 )
 
-if(MSVC AND DYNAMIC_SOLID AND ${CMAKE_MAJOR_VERSION} GREATER 2 AND ${CMAKE_MINOR_VERSION} GREATER 0)
+if(MSVC AND BUILD_SHARED_LIBS AND ${CMAKE_MAJOR_VERSION} GREATER 2 AND ${CMAKE_MINOR_VERSION} GREATER 0)
     install(FILES $<TARGET_PDB_FILE:solid3> DESTINATION ${CMAKE_INSTALL_BINDIR} CONFIGURATIONS Debug RelWithDebInfo COMPONENT debug)
 endif()


### PR DESCRIPTION
This patch adds a CMake option `USE_EXTERNAL_QHULL` for using an external Qhull library as well as support for the reentrant Qhull API, as the old one is [deprecated](https://github.com/qhull/qhull/blob/v8.0.0/src/libqhull/DEPRECATED.txt) and uses global variables.

It adds a CMake module for finding available Qhull installations. For this, it also replaces the `DYNAMIC_SOLID` option with the standard CMake flag [`BUILD_SHARED_LIBS`](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html) in order to select the appropriate library type.