### PR TITLE
Support double precision for DT_Scalar type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,9 +34,15 @@ option(USE_DOUBLES "Use double-precision floating-point numbers." OFF)
 
 if(USE_DOUBLES)
   add_definitions(-DUSE_DOUBLES)
+  set(DT_Scalar double)
+else()
+  set(DT_Scalar float)
 endif(USE_DOUBLES)
 
+configure_file(include/SOLID_precision.h.in include/SOLID_precision.h @ONLY)
+
 include_directories(
+	${PROJECT_BINARY_DIR}/include
 	${PROJECT_SOURCE_DIR}/include
 )
 

--- a/examples/dynamics/RigidBody.cpp
+++ b/examples/dynamics/RigidBody.cpp
@@ -35,8 +35,8 @@ void RigidBody::setGravity(const MT_Vector3& acceleration)
 
 void RigidBody::setDamping(MT_Scalar lin_damping, MT_Scalar ang_damping)
 {
-	m_lin_damping = GEN_clamped(1.0f - lin_damping, 0.0f, 1.0f);
-	m_ang_damping = GEN_clamped(1.0f - ang_damping, 0.0f, 1.0f);
+	m_lin_damping = GEN_clamped(MT_Scalar(1) - lin_damping, MT_Scalar(0), MT_Scalar(1));
+	m_ang_damping = GEN_clamped(MT_Scalar(1) - ang_damping, MT_Scalar(0), MT_Scalar(1));
 }
 
 void RigidBody::reset(const MT_Transform& xform)
@@ -69,7 +69,7 @@ void RigidBody::backup()
 
 inline MT_Scalar restitutionCurve(MT_Scalar rel_vel, MT_Scalar restitution)
 {
-	return restitution * GEN_min(1.0f, rel_vel / ContactThreshold);
+	return restitution * GEN_min(MT_Scalar(1), rel_vel / ContactThreshold);
 }
 
 void RigidBody::resolveCollision(const MT_Vector3& pos, 

--- a/examples/gldemo.cpp
+++ b/examples/gldemo.cpp
@@ -138,9 +138,9 @@ public:
 	{ 
 		glBegin(GL_TRIANGLES);
     
-		glVertex3fv(m_points[0]);
-		glVertex3fv(m_points[1]);
-		glVertex3fv(m_points[2]);
+		glVertex3f(m_points[0][0], m_points[0][1], m_points[0][2]);
+		glVertex3f(m_points[1][0], m_points[1][1], m_points[1][2]);
+		glVertex3f(m_points[2][0], m_points[2][1], m_points[2][2]);
 		
 	    glEnd();	
 	}
@@ -560,8 +560,8 @@ void display(void)
 #endif 
     {
         glBegin(GL_LINES);
-        glVertex3fv(cp1);
-        glVertex3fv(cp2);
+        glVertex3f(cp1[0], cp1[1], cp1[2]);
+        glVertex3f(cp2[0], cp2[1], cp2[2]);
 		glEnd();
 	}
 	
@@ -571,21 +571,21 @@ void display(void)
 	if (hit_client && param < 1.0f)
 	{
 		glBegin(GL_LINES);
-		glVertex3fv(source);
-		glVertex3fv(spot);
+		glVertex3f(source[0], source[1], source[2]);
+		glVertex3f(spot[0], spot[1], spot[2]);
 		glEnd();
 	
 		glColor3f(0.0f, 0.0f, 1.0f);
 		glBegin(GL_LINES);
-		glVertex3fv(spot);
-		glVertex3fv(target);
+		glVertex3f(spot[0], spot[1], spot[2]);
+		glVertex3f(target[0], target[1], target[2]);
 		glEnd();
 	}
 	else
 	{
 		glBegin(GL_LINES);
-		glVertex3fv(source);
-		glVertex3fv(target);
+		glVertex3f(source[0], source[1], source[2]);
+		glVertex3f(target[0], target[1], target[2]);
 		glEnd();
 	}
 
@@ -594,7 +594,7 @@ void display(void)
 		glPointSize(5);
 		glColor3f(1.0f, 1.0f, 1.0f);
         glBegin(GL_POINTS);
-        glVertex3fv(spot);
+        glVertex3f(spot[0], spot[1], spot[2]);
         glEnd();
         
 		glPointSize(1);
@@ -604,8 +604,9 @@ void display(void)
 		if (normal.length2() > 0.0f)
 		{
 			glBegin(GL_LINES);
-			glVertex3fv(spot);
-			glVertex3fv(spot + normal.normalized());
+			glVertex3f(spot[0], spot[1], spot[2]);
+			MT_Point3 tmp = spot + normal.normalized();
+			glVertex3f(tmp[0], tmp[1], tmp[2]);
 			glEnd();
 		}
     }
@@ -788,7 +789,7 @@ void separate()
 { 
 	if (separation.length2() != MT_Scalar(0.0))
 	{
-		pos2 += 0.01f * separation.normalized(); 
+		pos2 += MT_Scalar(0.01) * separation.normalized();
 	    doTest(); 
 	}
 }
@@ -797,7 +798,7 @@ void connect()
 { 
 	if (separation.length2() != MT_Scalar(0.0))
 	{
-		pos2 -= 0.01f * separation.normalized(); 
+		pos2 -= MT_Scalar(0.01) * separation.normalized();
 	    doTest(); 
 	} 
 }

--- a/examples/mnm.cpp
+++ b/examples/mnm.cpp
@@ -270,7 +270,7 @@ public:
 #ifdef DRAW_COORD
 		coordSystem();
 #endif
-		glColor3fv(m_color);
+		glColor3f(m_color[0], m_color[1], m_color[2]);
 		m_gl_shape->paint();
 		glPopMatrix();
 	}
@@ -353,10 +353,10 @@ DT_ShapeHandle createComplex()
             int j1 = j0 + 1;
 
 			MT_Vector3 verts[4];
-			verts[0].setValue(GRID_UNIT * i0, 0.25f * (i0*i0 + j0*j0), GRID_UNIT * j0);
-            verts[1].setValue(GRID_UNIT * i0, 0.25f * (i0*i0 + j1*j1), GRID_UNIT * j1);
-            verts[2].setValue(GRID_UNIT * i1, 0.25f * (i1*i1 + j1*j1), GRID_UNIT * j0);
-            verts[3].setValue(GRID_UNIT * i1, 0.25f * (i1*i1 + j0*j0), GRID_UNIT * j1);
+			verts[0].setValue(GRID_UNIT * i0, MT_Scalar(0.25) * (i0*i0 + j0*j0), GRID_UNIT * j0);
+            verts[1].setValue(GRID_UNIT * i0, MT_Scalar(0.25) * (i0*i0 + j1*j1), GRID_UNIT * j1);
+            verts[2].setValue(GRID_UNIT * i1, MT_Scalar(0.25) * (i1*i1 + j1*j1), GRID_UNIT * j0);
+            verts[3].setValue(GRID_UNIT * i1, MT_Scalar(0.25) * (i1*i1 + j0*j0), GRID_UNIT * j1);
 #ifdef USE_QUADS
             DT_Begin();
             DT_Vertex(verts[0]);
@@ -433,7 +433,7 @@ DT_Bool body2body_fix(void *client_data,
 	Object& obj2 = *(Object *)object2;
 	MT_Vector3 normal(coll_data->normal);	
    
-	MT_Vector3 error = normal * 0.5f;
+	MT_Vector3 error = normal * MT_Scalar(0.5);
 	obj1.correct(error);
 	obj2.correct(-error);	
 	
@@ -500,7 +500,7 @@ void display(void)
 static MT_Scalar DISTANCE = 20; 
 
 static MT_Scalar ele = 0, azi = 0;
-static MT_Point3 eye(0.0f, 0.0f, DISTANCE);
+static MT_Point3 eye(MT_Scalar(0), MT_Scalar(0), DISTANCE);
 static MT_Point3 center(0, 0, 0);
 
 inline double irnd() { return 2 * MT_random() - 1; }  

--- a/examples/physics.cpp
+++ b/examples/physics.cpp
@@ -233,9 +233,9 @@ public:
  	void setTransform(const MT_Transform& xform)
 	{
 		RigidBody::setTransform(xform);	
-		float m[16];
+		DT_Scalar m[16];
 		xform.getValue(m);
-		DT_SetMatrixf(m_object, m);
+		DT_SetMatrix(m_object, m);
 		DT_SetScaling(m_object, m_scaling);
 	}
 	
@@ -249,9 +249,9 @@ public:
     void proceed(MT_Scalar step)
 	{
 		RigidBody::proceed(step);
-		float m[16];
+		DT_Scalar m[16];
 		m_xform.getValue(m);
-		DT_SetMatrixf(m_object, m);
+		DT_SetMatrix(m_object, m);
 		DT_SetScaling(m_object, m_scaling);
 	}
 	
@@ -269,7 +269,7 @@ public:
 #ifdef DRAW_COORD
 		coordSystem();
 #endif
-		glColor3fv(m_color);
+		glColor3f(m_color[0], m_color[1], m_color[2]);
 		m_gl_shape->paint();
 		glPopMatrix();
 	}
@@ -434,7 +434,7 @@ DT_Bool body2body_fix(void *client_data,
 	Object& obj2 = *(Object *)object2;
 	MT_Vector3 normal(coll_data->normal);	
    
-	MT_Vector3 error = normal * 0.5f;
+	MT_Vector3 error = normal * MT_Scalar(0.5);
 	obj1.correct(error);
 	obj2.correct(-error);
 	
@@ -498,7 +498,7 @@ void display(void)
 static MT_Scalar DISTANCE = 20; 
 
 static MT_Scalar ele = 0, azi = 0;
-static MT_Point3 eye(0.0f, 0.0f, DISTANCE);
+static MT_Point3 eye(MT_Scalar(0), MT_Scalar(0), DISTANCE);
 static MT_Point3 center(0, 0, 0);
 
 inline double irnd() { return 2 * MT_random() - 1; }  

--- a/include/SOLID.h
+++ b/include/SOLID.h
@@ -137,6 +137,9 @@ extern "C" {
 
 /* These commands assume a column-major 4x4 OpenGL matrix representation */
 
+	DECLSPEC void DT_SetMatrix(DT_ObjectHandle object, const DT_Scalar *m);
+	DECLSPEC void DT_GetMatrix(DT_ObjectHandle object, DT_Scalar *m);
+
 	DECLSPEC void DT_SetMatrixf(DT_ObjectHandle object, const float *m); 
 	DECLSPEC void DT_GetMatrixf(DT_ObjectHandle object, float *m); 
 

--- a/include/SOLID_precision.h.in
+++ b/include/SOLID_precision.h.in
@@ -21,37 +21,9 @@
  * use of this library.
  */
 
-#ifndef SOLID_TYPES_H
-#define SOLID_TYPES_H
+#ifndef SOLID_PRECISION_H
+#define SOLID_PRECISION_H
 
-#if defined(_WIN32)
-#   if defined(SOLID_STATIC)
-#      define DECLSPEC extern
-#   elif defined(SOLID_DLL_EXPORT)
-#      define DECLSPEC __declspec(dllexport)
-#   else 
-#      define DECLSPEC __declspec(dllimport)
-#   endif
-#else
-#   define DECLSPEC extern
-#endif
-
-#define DT_DECLARE_HANDLE(name) typedef struct name##__ { int unused; } *name
-    
-#include "SOLID_precision.h"
-
-typedef unsigned int   DT_Index;
-typedef unsigned int   DT_Count;
-typedef unsigned int   DT_Size;
-typedef int            DT_Bool;
-
-#define DT_FALSE 0
-#define DT_TRUE  1
-
-#define DT_CONTINUE 0
-#define DT_DONE 1
-
-typedef DT_Scalar DT_Vector3[3]; 
-typedef DT_Scalar DT_Quaternion[4]; 
+typedef @DT_Scalar@ DT_Scalar;
 
 #endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,6 +16,7 @@ include_directories(${PROJECT_SOURCE_DIR}/src/complex)
 set(SOLID_PUBLIC_HEADERS 
   ${PROJECT_SOURCE_DIR}/include/SOLID.h
   ${PROJECT_SOURCE_DIR}/include/SOLID_broad.h
+  ${PROJECT_BINARY_DIR}/include/SOLID_precision.h
   ${PROJECT_SOURCE_DIR}/include/SOLID_types.h
 )
 

--- a/src/DT_C-api.cpp
+++ b/src/DT_C-api.cpp
@@ -357,6 +357,18 @@ void DT_SetOrientation(DT_ObjectHandle object, const DT_Quaternion orientation)
 }
 
 
+void DT_SetMatrix(DT_ObjectHandle object, const DT_Scalar *m)
+{
+	assert(object);
+	reinterpret_cast<DT_Object *>(object)->setMatrix(m);
+}
+
+void DT_GetMatrix(DT_ObjectHandle object, DT_Scalar *m)
+{
+	assert(object);
+	reinterpret_cast<DT_Object *>(object)->getMatrix(m);
+}
+
 void DT_SetMatrixf(DT_ObjectHandle object, const float *m) 
 {
 	assert(object);


### PR DESCRIPTION
This patch adds support for double precision in the `DT_Scalar` type when using the `USE_DOUBLES` option, similar to `MT_Scalar`. The type is currently fixed to `float` and therefore results in limited precision and incorrect results when positioning and querying objects.

It also fixes building the examples with double precision, as this currently results in a number of errors due to mixing `MT_Scalar` with `float` types:
```
examples/dynamics/RigidBody.cpp: In member function ‘void RigidBody::setDamping(MT_Scalar, MT_Scalar)’:
examples/dynamics/RigidBody.cpp:38:60: error: no matching function for call to ‘GEN_clamped(MT_Scalar, float, float)’
   38 |  m_lin_damping = GEN_clamped(1.0f - lin_damping, 0.0f, 1.0f);
```

It further adds `DT_GetMatrix` and `DT_SetMatrix` functions for the `DT_Scalar` type similar to `DT_SetPosition` etc. in order to avoid checking for the correct type when reading or updating the matrix of an object.