### PR TITLE
Add CMake option for disabling examples

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,8 +68,12 @@ if (WIN32)
 endif(WIN32)
 
 
-find_package(GLUT)
-find_package(OpenGL)
+option(BUILD_EXAMPLES "Build examples." ON)
+
+if(BUILD_EXAMPLES)
+  find_package(GLUT)
+  find_package(OpenGL)
+endif()
 
 
 if(MSVC) 
@@ -97,7 +101,9 @@ if(UNIX)
 endif(UNIX)
 
 add_subdirectory(src)
-add_subdirectory(examples)
+if(BUILD_EXAMPLES)
+  add_subdirectory(examples)
+endif()
 #add_subdirectory(doc)
 
 include(CMakePackageConfigHelpers)


### PR DESCRIPTION
This patch adds a CMake option for building the examples. This should be optional, as they are not required for building the library and currently fail to build when using double precision.